### PR TITLE
add route to GET /api/version and return package.json version

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -248,6 +248,274 @@
         }
       }
     },
+    "/api/movie/": {
+      "get": {
+        "tags": [
+          "movies"
+        ],
+        "summary": "get all movies",
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "movies"
+        ],
+        "summary": "Add a new Movie",
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "Success: Movie was updated successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Movie"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Movie"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request: Data to update can not be empty!"
+          },
+          "404": {
+            "description": "Not found: Cannot update Movie with id. Maybe Movie was not found!"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Movie"
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "movies"
+        ],
+        "summary": "delete all Movies",
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/api/movie/{id}": {
+      "get": {
+        "tags": [
+          "movies"
+        ],
+        "summary": "get a single movie by id",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID of the user to retrieve"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "404": {
+            "description": "Not found: Movie with id"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "movies"
+        ],
+        "summary": "update a Movie by id",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Movie ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success: Movie was updated successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Movie"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Movie"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request: Data to update can not be empty!"
+          },
+          "404": {
+            "description": "Not found: Cannot update Movie with id. Maybe Movie was not found!"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Movie"
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "movies"
+        ],
+        "summary": "delete a single Movie by id",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Movie ID"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success: Movie was deleted successfully!"
+          },
+          "404": {
+            "description": "Not found: Cannot delete Movie with id. Movie not found!"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/movie/{movieName}": {
+      "get": {
+        "tags": [
+          "movies"
+        ],
+        "summary": "get a single movie by id",
+        "description": "",
+        "parameters": [
+          {
+            "name": "movieName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "description": "ID of the user to retrieve",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "404": {
+            "description": "Not found: Movie with id"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/movie/{id}/toggleActiveStatus": {
+      "patch": {
+        "tags": [
+          "movies"
+        ],
+        "summary": "toggle a Movie active status by id",
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Movie ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success: Movie active status was toggled successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Movie"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Movie"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request: Data to update can not be empty!"
+          },
+          "404": {
+            "description": "Not found: Cannot toggle Movie active status with id. Movie not found!"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
     "/api/users/": {
       "get": {
         "tags": [
@@ -588,270 +856,16 @@
         }
       }
     },
-    "/api/movie/": {
+    "/api/version/": {
       "get": {
         "tags": [
-          "movies"
+          "status"
         ],
-        "summary": "get all movies",
+        "summary": "report API Version",
         "description": "",
         "responses": {
           "200": {
-            "description": "Success"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "movies"
-        ],
-        "summary": "Add a new Movie",
-        "description": "",
-        "responses": {
-          "200": {
-            "description": "Success: Movie was updated successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Movie"
-                }
-              },
-              "application/xml": {
-                "schema": {
-                  "$ref": "#/components/schemas/Movie"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request: Data to update can not be empty!"
-          },
-          "404": {
-            "description": "Not found: Cannot update Movie with id. Maybe Movie was not found!"
-          }
-        },
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Movie"
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "movies"
-        ],
-        "summary": "delete all Movies",
-        "description": "",
-        "responses": {
-          "default": {
-            "description": ""
-          }
-        }
-      }
-    },
-    "/api/movie/{id}": {
-      "get": {
-        "tags": [
-          "movies"
-        ],
-        "summary": "get a single movie by id",
-        "description": "",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "ID of the user to retrieve"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "404": {
-            "description": "Not found: Movie with id"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "movies"
-        ],
-        "summary": "update a Movie by id",
-        "description": "",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Movie ID"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success: Movie was updated successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Movie"
-                }
-              },
-              "application/xml": {
-                "schema": {
-                  "$ref": "#/components/schemas/Movie"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request: Data to update can not be empty!"
-          },
-          "404": {
-            "description": "Not found: Cannot update Movie with id. Maybe Movie was not found!"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        },
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Movie"
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "movies"
-        ],
-        "summary": "delete a single Movie by id",
-        "description": "",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Movie ID"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success: Movie was deleted successfully!"
-          },
-          "404": {
-            "description": "Not found: Cannot delete Movie with id. Movie not found!"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        }
-      }
-    },
-    "/api/movie/{movieName}": {
-      "get": {
-        "tags": [
-          "movies"
-        ],
-        "summary": "get a single movie by id",
-        "description": "",
-        "parameters": [
-          {
-            "name": "movieName",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "id",
-            "description": "ID of the user to retrieve",
-            "in": "path",
-            "schema": {
-              "type": "string"
-            },
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "404": {
-            "description": "Not found: Movie with id"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        }
-      }
-    },
-    "/api/movie/{id}/toggleActiveStatus": {
-      "patch": {
-        "tags": [
-          "movies"
-        ],
-        "summary": "toggle a Movie active status by id",
-        "description": "",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Movie ID"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success: Movie active status was toggled successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Movie"
-                }
-              },
-              "application/xml": {
-                "schema": {
-                  "$ref": "#/components/schemas/Movie"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request: Data to update can not be empty!"
-          },
-          "404": {
-            "description": "Not found: Cannot toggle Movie active status with id. Movie not found!"
-          },
-          "500": {
-            "description": "Internal server error"
+            "description": "OK"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superhero-api",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "BYUI CSE341 Team 19 project",
   "main": "server.js",
   "scripts": {

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,22 +1,23 @@
-const express = require('express')
-const router = express.Router()
-const apiRouter = express.Router()
+const express = require("express");
+const router = express.Router();
+const apiRouter = express.Router();
 
-const comicRoutes = require('./comic-routes.js') // HOT
-const userRoutes = require('./user-routes.js')
-const movieRouter = require('./movie-route.js')
-const authRoutes = require('./auth-routes.js')
-const swaggerUi = require('swagger-ui-express')
-const swaggerDocument = require('../docs/openapi.json')
-
+const comicRoutes = require("./comic-routes.js"); // HOT
+const movieRouter = require("./movie-route.js");
+const userRoutes = require("./user-routes.js");
+const versionRoutes = require("./version-routes.js");
+const authRoutes = require("./auth-routes.js");
+const swaggerUi = require("swagger-ui-express");
+const swaggerDocument = require("../docs/openapi.json");
 
 // const passport = require('passport')
-router.use('/api', apiRouter)
+router.use("/api", apiRouter);
 
-apiRouter.use('/comics', comicRoutes)
-apiRouter.use('/users', userRoutes)
-apiRouter.use('/movie', movieRouter)
-apiRouter.use('/auth', authRoutes)
-apiRouter.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument))
+apiRouter.use("/comics", comicRoutes);
+apiRouter.use("/movie", movieRouter);
+apiRouter.use("/users", userRoutes);
+apiRouter.use("/version", versionRoutes);
+apiRouter.use("/auth", authRoutes);
+apiRouter.use("/docs", swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
-module.exports = router
+module.exports = router;

--- a/routes/version-routes.js
+++ b/routes/version-routes.js
@@ -1,0 +1,13 @@
+const packageJson = require("../package.json");
+const versionRouter = require("express").Router();
+
+versionRouter.get(
+  "/",
+  // #swagger.summary = 'report API Version'
+  // #swagger.tags = ['status']
+  (req, res) => {
+    res.send({ version: packageJson.version });
+  }
+);
+
+module.exports = versionRouter;


### PR DESCRIPTION
Added a new route to GET the API version from the package.json file so that anyone can know which version they are using - especially during testing.  Be sure to increment the version in package.json before every push to Git Hub (see the workflow in readme.md.